### PR TITLE
Fix issue with cifuzz job

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -23,7 +23,7 @@ jobs:
         fuzz-seconds: 300
         output-sarif: true
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts


### PR DESCRIPTION
Due to this announcement - https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
we need to change this to v4